### PR TITLE
Fix importing issue with Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "The JavaScript library for https://extensionpay.com - payments for browser extensions, no server needed.",
   "main": "./dist/ExtPay.common.js",
   "module": "./dist/ExtPay.module.js",
-  "browser": "./dist/ExtPay.js",
   "unpkg": "./dist/ExtPay.js",
   "jsdelivr": "./dist/ExtPay.js",
   "scripts": {


### PR DESCRIPTION
## Description

I noticed in this issue that importing this library does not work with Webpack correctly https://github.com/Glench/ExtPay/issues/41

## Solution

The solution is to remove `browser` field because it was pointing to version of global ExtPay which is meant to be used when you want to have global variable `ExtPay`. But since `package.json` is meant for npm modules this is not what we want to do.

Very big libraries which are meant for browser do no use `browser` field of `package.json`. Great example from Vue.js (https://github.com/vuejs/vue/blob/main/package.json#L6). They only specify `main` + other fields but nobody uses `browser`.

## How to test?

Use ExtPay library in Webpack and Rollup or some other bundler and see if you can now just import ExtPay like this
```ts
import ExtPay from 'extpay';

const extPay = ExtPay("some-id");
```
 and run the code to see if you get any errors. If you don't then everything is cool!

Fixes #41 